### PR TITLE
Format time like isoformat() would

### DIFF
--- a/cee_formatter.py
+++ b/cee_formatter.py
@@ -43,7 +43,8 @@ class CEEFormatter(logging.Formatter):
     def format(self, log_record):
         record = OrderedDict()
 
-        record['time'] = self.formatTime(log_record)
+        record['time'] = datetime.utcfromtimestamp(log_record.created)
+
         record['msg'] = log_record.getMessage()
         record['pid'] = log_record.process
         record['tid'] = log_record.thread

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+iso8601==0.1.11
 pyflakes==1.2.3
 pytest==3.0.1
 pytest-flake8==0.6

--- a/test_format.py
+++ b/test_format.py
@@ -2,6 +2,8 @@ import datetime
 import json
 import logging
 
+import iso8601
+
 from cee_formatter import CEEFormatter
 
 try:
@@ -36,3 +38,11 @@ def test_datetime_format():
     json_dict = json.loads(json_value)
 
     assert json_dict['d'] == date.isoformat()
+
+    # We want to make sure that the time is in full ISO8601 format so
+    # we don't lose too much precision (it'll be microseconds).
+    # This assertion can generate a false positive when timestamp has
+    # a zero microsecond part but I think we can live with it.
+    serialized_timestamp = json_dict['time']
+    timestamp = iso8601.parse_date(serialized_timestamp).replace(tzinfo=None)
+    assert serialized_timestamp == timestamp.isoformat()


### PR DESCRIPTION
In many applications millisecond precision is not enough to understand
what's going on, let's stick to microsecond-precision like with
isoformat(). Additionally the separators are changed to match those of
isoformat() (which is used to format other timestamps here).
